### PR TITLE
Fix release wheel tests: X11 libs, test config, drop Intel macOS

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,9 +21,9 @@ jobs:
           - os: windows-latest
             platform: Windows AMD64
             artifact: windows-amd64
-          - os: macos-15-intel
-            platform: macOS x86_64
-            artifact: macos-x86_64
+          # No Intel macOS target: numba's llvmlite dependency no longer
+          # publishes macOS x86_64 wheels, and building it from source needs
+          # an LLVM toolchain the runner does not carry.
           - os: macos-latest
             platform: macOS arm64
             artifact: macos-arm64

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ In DEISM-ARG, we can model the room transfer function between transducers mounte
 
 # Installation
 
-DEISM supports Python 3.10, 3.11, and 3.12 on Windows, macOS, and Linux.
+DEISM supports Python 3.10, 3.11, and 3.12 on Windows, Linux, and Apple
+Silicon macOS. Intel macOS is not supported, because the `numba` dependency no
+longer builds there.
 The current documentation is organized around the class-based workflow
 implemented by `deism.core_deism.DEISM`.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -39,8 +39,8 @@ changelog; update it when cutting a release.
   again; the compact-vs-legacy comparison moved to the new
   ``examples/deism_arg_compact_compare.py``.
 - Python 3.10 is now the minimum supported version. Release wheels are built
-  and tested for Python 3.10, 3.11, and 3.12 on Linux, Windows, Intel macOS,
-  and Apple Silicon macOS.
+  and tested for Python 3.10, 3.11, and 3.12 on Linux, Windows, and Apple
+  Silicon macOS.
 - The shoebox reflection counter is now a regular pybind11 extension built by
   the platform-native toolchain and verified alongside ``libroom_deism``.
 - CI now runs the critical suite on Python 3.12 across all three operating

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,15 +1,21 @@
 Installation
 ============
 
-DEISM supports Python 3.10, 3.11, and 3.12 on Windows, macOS, and Linux. This
-page uses the same installation guidance as the repository ``README.md``.
+DEISM supports Python 3.10, 3.11, and 3.12 on Windows, Linux, and Apple
+Silicon macOS. This page uses the same installation guidance as the repository
+``README.md``.
 
 Supported environments
 ----------------------
 
 The project metadata requires Python 3.10 or newer. Per-commit CI tests Python
 3.12 on Windows, macOS, and Linux. Release CI additionally builds and tests
-Python 3.10 and 3.11 wheels on all supported platforms.
+Python 3.10 and 3.11 wheels for Linux x86_64, Windows AMD64, and Apple Silicon
+macOS.
+
+Intel macOS is not supported. DEISM depends on ``numba``, whose ``llvmlite``
+dependency no longer ships macOS x86_64 wheels, so neither a binary wheel nor
+a source install can be produced for that platform.
 
 Check Python version
 --------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,13 +74,20 @@ test-requires = ["pytest"]
 test-sources = [
   "deism/tests/test_deism_arg.py",
   "deism/tests/test_native_components.py",
+  # readYaml() resolves default configs against ./examples, so the wheel test
+  # directory needs the config the convex-room test loads. Copy the file, not
+  # the directory -- examples/data is ~186 MB.
+  "examples/configSingleParam_ARG_RIR.yml",
 ]
 test-command = "python -m pytest deism/tests/test_deism_arg.py deism/tests/test_native_components.py"
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64"]
 manylinux-x86_64-image = "manylinux_2_28"
-before-all = "dnf install -y mesa-libGLU libglvnd-glx"
+# The full DT_NEEDED set of the bundled libgmsh.so, minus the glibc/libstdc++
+# runtime the image already provides. The manylinux image is far leaner than a
+# GitHub Ubuntu runner, so every X11 library has to be named explicitly.
+before-all = "dnf install -y mesa-libGLU libglvnd-glx libX11 libXext libXrender libXfixes libXcursor libXinerama libXft fontconfig"
 
 [tool.cibuildwheel.windows]
 archs = ["AMD64"]


### PR DESCRIPTION
Fixes the three cibuildwheel failures that blocked the 2.2.1.15 publish. See commit message for per-platform detail.