### PR TITLE
Bundle the default YAML configs as package resources

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -71,7 +71,7 @@ jobs:
           /tmp/deism-sdist-smoke/bin/python -m pip install --upgrade pip
           /tmp/deism-sdist-smoke/bin/python -m pip install dist/*.tar.gz
           cd /tmp
-          /tmp/deism-sdist-smoke/bin/python -c "from deism import libroom_deism; from deism.count_reflections_wrapper import CPP_COUNTING_AVAILABLE, count_reflections_cpp; assert libroom_deism is not None; assert CPP_COUNTING_AVAILABLE; assert count_reflections_cpp(0, (3, 4, 5), 343, 1) == 1"
+          /tmp/deism-sdist-smoke/bin/python -c "from deism import DEISM, libroom_deism; from deism.count_reflections_wrapper import CPP_COUNTING_AVAILABLE, count_reflections_cpp; assert libroom_deism is not None; assert CPP_COUNTING_AVAILABLE; assert count_reflections_cpp(0, (3, 4, 5), 343, 1) == 1; assert DEISM('RIR', 'convex', silent=True) is not None"
 
       - name: Upload source distribution
         uses: actions/upload-artifact@v4

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -22,6 +22,10 @@ prune benchmarks
 prune development
 prune docs
 prune examples
+# Restore the internal deism.examples package after pruning the large example
+# tree. examples/data and other non-package assets remain excluded.
+include examples/*.py
+include examples/configSingleParam*.yml
 prune playground
 prune tests
 prune tools

--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ DEISM selects its default YAML configuration from the pair `(mode, roomtype)`:
 | `RTF` | `convex` | `examples/configSingleParam_ARG_RTF.yml` |
 | `RIR` | `convex` | `examples/configSingleParam_ARG_RIR.yml` |
 
+These files are also bundled with installed wheels and source distributions.
+Repository-local files retain precedence, while an installed package falls
+back to its bundled defaults when invoked from another working directory.
+
 ## Workflow order
 
 Shoebox workflow:

--- a/deism/data_loader.py
+++ b/deism/data_loader.py
@@ -1,10 +1,22 @@
-import fnmatch
+from importlib import resources
+from pathlib import Path
+
 import yaml
 import argparse
 import os
 import sys
 import scipy.io as sio
 import numpy as np
+
+
+_DEFAULT_CONFIG_NAMES = frozenset(
+    {
+        "configSingleParam_RTF.yml",
+        "configSingleParam_RIR.yml",
+        "configSingleParam_ARG_RTF.yml",
+        "configSingleParam_ARG_RIR.yml",
+    }
+)
 
 
 class ConflictChecks:
@@ -388,38 +400,72 @@ def detect_conflicts(params):
 
 
 def readYaml(filePath):
-    """
-    This function reads the yaml file and returns a dictionary with the same structure as the yaml file
-    inputs:
-    - filePath: the address of the yaml file to be read, including the file name with the suffix
-    outputs:
-    - yaml->dict: a dictionary with the same structure as the yaml file
-    """
-    # First determine if the file path exists
-    # Either in the .test/ directory or in the specified directory
-    # Use try to find the file in the tests/ directory
-    # if it is found, add tests/ to the file path
-    try:
-        # If the file is found, assign the file path to filePath
-        if fnmatch.filter(os.listdir("examples"), filePath):
-            filePath = "examples/" + filePath
-        # If the file is not found, an exception is raised
-    except:
-        # If the file is not found, assign the file path to filePath
-        filePath = filePath
-    # Then determine if the file path exists
-    if not os.path.exists(filePath):
-        # If it does not exist, an exception is thrown
-        raise FileNotFoundError(f"{filePath} doesn't exist!")
+    """Read a YAML configuration and convert list values to NumPy arrays.
 
-    # Then determine if it is a file
-    if not os.path.isfile(filePath):
-        # raise an exception if it is not a file
-        raise FileNotFoundError(f"{filePath} is not a file!")
+    Explicit paths, including paths beginning with ``./`` or ``.\\``, are
+    resolved strictly. For a bare filename, lookup preserves the historical
+    order: ``./examples/<name>``, then ``./<name>``, then the defaults bundled
+    in ``deism.examples``. The package-resource fallback is limited to the four
+    default DEISM configuration names.
 
-    # Load yaml normally and return
-    with open(filePath, "r") as stream:
-        configs = yaml.safe_load(stream)
+    Parameters
+    ----------
+    filePath : str or os.PathLike
+        YAML path or bare configuration filename.
+
+    Returns
+    -------
+    dict
+        The parsed YAML structure.
+    """
+    raw_path = os.fspath(filePath)
+    requested_path = Path(raw_path)
+    current_directory_prefixes = tuple(
+        f".{separator}"
+        for separator in (os.sep, os.altsep)
+        if separator is not None
+    )
+    has_explicit_current_directory = raw_path.startswith(
+        current_directory_prefixes
+    )
+
+    # Paths with an explicit directory component are strict: a missing custom
+    # path must not silently fall back to a bundled default with the same name.
+    if (
+        requested_path.is_absolute()
+        or requested_path.parent != Path(".")
+        or has_explicit_current_directory
+    ):
+        if not requested_path.exists():
+            raise FileNotFoundError(f"{requested_path} doesn't exist!")
+        if not requested_path.is_file():
+            raise FileNotFoundError(f"{requested_path} is not a file!")
+        config_text = requested_path.read_text(encoding="utf-8")
+    else:
+        # Preserve the historical precedence for bare names: a repository's
+        # ./examples copy wins over a same-named file in the current directory.
+        example_path = Path("examples") / requested_path.name
+        if example_path.is_file():
+            config_text = example_path.read_text(encoding="utf-8")
+        elif requested_path.is_file():
+            config_text = requested_path.read_text(encoding="utf-8")
+        elif requested_path.name in _DEFAULT_CONFIG_NAMES:
+            try:
+                resource_root = resources.files("deism.examples")
+            except ImportError as exc:
+                raise FileNotFoundError(
+                    f"{requested_path} doesn't exist! Bundled defaults are "
+                    "unavailable because deism.examples is not importable; "
+                    "reinstall the package."
+                ) from exc
+            resource = resource_root.joinpath(requested_path.name)
+            if not resource.is_file():
+                raise FileNotFoundError(f"{requested_path} doesn't exist!")
+            config_text = resource.read_text(encoding="utf-8")
+        else:
+            raise FileNotFoundError(f"{requested_path} doesn't exist!")
+
+    configs = yaml.safe_load(config_text)
     # The arrays read directly from yaml are in list format, so they are converted to numpy format
     # Convert the arrays in it to numpy arrays
     for key, value in configs.items():

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -47,5 +47,8 @@ changelog; update it when cutting a release.
   systems, on both pull requests and pushes to ``main``.
 - Release artifacts are built and tested with cibuildwheel, aggregated into a
   single validated publish job, and rehearsed without upload for prereleases.
+- The four default YAML configurations under ``examples/`` are bundled as
+  package resources, so an installed wheel or sdist works outside a repository
+  checkout while repository-local configurations retain precedence.
 - The conda development environment (``deism_env.yml``) moved to Python 3.12;
   the stale Python 3.9 lock file ``deism_env_exact.yml`` was removed.

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Examples and default configuration resources for DEISM."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,10 +74,6 @@ test-requires = ["pytest"]
 test-sources = [
   "deism/tests/test_deism_arg.py",
   "deism/tests/test_native_components.py",
-  # readYaml() resolves default configs against ./examples, so the wheel test
-  # directory needs the config the convex-room test loads. Copy the file, not
-  # the directory -- examples/data is ~186 MB.
-  "examples/configSingleParam_ARG_RIR.yml",
 ]
 test-command = "python -m pytest deism/tests/test_deism_arg.py deism/tests/test_native_components.py"
 

--- a/setup.py
+++ b/setup.py
@@ -233,7 +233,13 @@ setup_kwargs = dict(
     name="deism",
     version=__version__,
     # packages=find_packages(),
-    packages=["deism"],
+    # Keep the example YAML files as the single source of truth while exposing
+    # them from installed distributions through the internal deism.examples
+    # resource package. The small Python examples are intentionally shipped;
+    # examples/data remains excluded from package data and MANIFEST.in.
+    packages=["deism", "deism.examples"],
+    package_dir={"deism.examples": "examples"},
+    package_data={"deism.examples": ["configSingleParam*.yml"]},
     description="An image source-based method used to simulate room transfer functions for arbitrary room shapes.",
     long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
@@ -248,10 +254,6 @@ setup_kwargs = dict(
     # Wheels need only the Python modules and compiled extensions. Native
     # sources are included in sdists explicitly by MANIFEST.in.
     include_package_data=False,
-    # Necessary to keep the source files
-    # package_data={"DEISM": ["*.pxd", "*.pyx", "data/materials.json"]},
-    # here controls where the pyd shared lib will be copied.
-    # package_dir={"": os.path.join(os.getcwd(), "deism")},
     python_requires=">=3.10",
     cmdclass={
         "build_ext": BuildExt,

--- a/tests/test_packaged_default_configs.py
+++ b/tests/test_packaged_default_configs.py
@@ -1,0 +1,122 @@
+"""Regression tests for filesystem and installed-resource YAML lookup."""
+
+import os
+from importlib import resources
+
+import numpy as np
+import pytest
+
+from deism.data_loader import readYaml
+
+
+DEFAULT_CONFIG_NAMES = (
+    "configSingleParam_RTF.yml",
+    "configSingleParam_RIR.yml",
+    "configSingleParam_ARG_RTF.yml",
+    "configSingleParam_ARG_RIR.yml",
+)
+
+
+@pytest.mark.parametrize("config_name", DEFAULT_CONFIG_NAMES)
+def test_default_configs_are_packaged_and_readable_from_empty_cwd(
+    config_name, tmp_path, monkeypatch
+):
+    resource = resources.files("deism.examples").joinpath(config_name)
+    assert resource.is_file()
+
+    monkeypatch.chdir(tmp_path)
+    configs = readYaml(config_name)
+
+    assert configs
+    assert "Environment" in configs
+
+
+def test_explicit_path_is_strict_and_overrides_packaged_default(tmp_path):
+    custom_dir = tmp_path / "custom"
+    custom_dir.mkdir()
+    custom_path = custom_dir / "configSingleParam_RIR.yml"
+    custom_path.write_text("origin: explicit\nvalues: [1, 2]\n", encoding="utf-8")
+
+    configs = readYaml(custom_path)
+
+    assert configs["origin"] == "explicit"
+    np.testing.assert_array_equal(configs["values"], np.array([1, 2]))
+
+
+def test_missing_explicit_path_does_not_fall_back_to_packaged_default(tmp_path):
+    missing_path = tmp_path / "missing" / "configSingleParam_RIR.yml"
+
+    with pytest.raises(FileNotFoundError, match="doesn't exist"):
+        readYaml(missing_path)
+
+
+def test_examples_directory_keeps_precedence_for_bare_names(tmp_path, monkeypatch):
+    config_name = "configSingleParam_RIR.yml"
+    examples_dir = tmp_path / "examples"
+    examples_dir.mkdir()
+    (examples_dir / config_name).write_text("origin: examples\n", encoding="utf-8")
+    (tmp_path / config_name).write_text("origin: current-directory\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    configs = readYaml(config_name)
+
+    assert configs["origin"] == "examples"
+
+
+def test_bare_name_resolves_from_current_directory(tmp_path, monkeypatch):
+    config_name = "local-config.yml"
+    (tmp_path / config_name).write_text(
+        "origin: current-directory\nvalues: [3, 4]\n", encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+
+    configs = readYaml(config_name)
+
+    assert configs["origin"] == "current-directory"
+    np.testing.assert_array_equal(configs["values"], np.array([3, 4]))
+
+
+def test_explicit_current_directory_path_does_not_prefer_examples(
+    tmp_path, monkeypatch
+):
+    config_name = "configSingleParam_RIR.yml"
+    examples_dir = tmp_path / "examples"
+    examples_dir.mkdir()
+    (examples_dir / config_name).write_text("origin: examples\n", encoding="utf-8")
+    (tmp_path / config_name).write_text(
+        "origin: explicit-current-directory\n", encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+
+    configs = readYaml(f".{os.sep}{config_name}")
+
+    assert configs["origin"] == "explicit-current-directory"
+
+
+def test_missing_packaged_defaults_report_reinstall_guidance(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+
+    def unavailable_package(_package_name):
+        raise ModuleNotFoundError("No module named 'deism.examples'")
+
+    monkeypatch.setattr(resources, "files", unavailable_package)
+
+    with pytest.raises(FileNotFoundError, match="reinstall the package"):
+        readYaml("configSingleParam_RIR.yml")
+
+
+def test_unknown_bare_name_still_raises(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="doesn't exist"):
+        readYaml("not-a-default.yml")
+
+
+def test_explicit_directory_is_not_a_file(tmp_path):
+    directory = tmp_path / "config-directory"
+    directory.mkdir()
+
+    with pytest.raises(FileNotFoundError, match="is not a file"):
+        readYaml(directory)


### PR DESCRIPTION
Installed distributions can now load their own default configs. The four YAML files stay in examples/ as the single source of truth, exposed as the deism.examples resource package. Wheel tests exercise the installed resource instead of a copied file.